### PR TITLE
Fixes

### DIFF
--- a/src/main/java/com/github/jomnipod/IBF.java
+++ b/src/main/java/com/github/jomnipod/IBF.java
@@ -34,12 +34,21 @@ public class IBF {
 
 	private IBFVersions versions;
 
+	private PDMVersion pdmVersion;
+
+	private boolean isDash;
+
 	private List<LogRecord> logRecords;
 
 	public IBF(InputStream inputStream) throws IOException {
 		versions = new IBFVersions(new IBFRecord(inputStream));
-
-		inputStream.read(new byte[46], 0, 46);
+		IBFRecord pdmVersionRecord = new IBFRecord(inputStream);
+		pdmVersion = new PDMVersion(pdmVersionRecord.iterator());
+		Version dashVersion = new Version(3,0,0);
+		if (pdmVersion.compareTo(dashVersion) >= 0) {
+			isDash = true;
+		}
+		IBFRecord manufacturingData = new IBFRecord(inputStream);
 
 		BasalPrograms basalPrograms = new BasalPrograms(new IBFRecord(inputStream));
 
@@ -68,11 +77,19 @@ public class IBF {
 		logRecords = tmpLogRecords;
 	}
 
-	public Version version() {
-		return versions.ibfVersion();
+	public IBFVersions ibfVersions() {
+		return versions;
+	}
+
+	public PDMVersion pdmVersion(){
+		return pdmVersion;
 	}
 
 	public List<LogRecord> logRecords() {
 		return new ArrayList<>(logRecords);
+	}
+
+	public boolean isDash() {
+		return isDash;
 	}
 }

--- a/src/main/java/com/github/jomnipod/IBFVersion.java
+++ b/src/main/java/com/github/jomnipod/IBFVersion.java
@@ -28,7 +28,7 @@ import com.github.jomnipod.IBFRecord.Iterator;
 public class IBFVersion extends Version {
 
 	public IBFVersion(Iterator iterator) {
-		super(iterator.nextByte().intValue(), iterator.nextByte().intValue(), iterator.nextByte().intValue());
+		super(iterator.nextUnsignedBEShort(), iterator.nextUnsignedBEShort(), iterator.nextUnsignedBEShort());
 	}
 
 }

--- a/src/main/java/com/github/jomnipod/PDMVersion.java
+++ b/src/main/java/com/github/jomnipod/PDMVersion.java
@@ -1,0 +1,9 @@
+package com.github.jomnipod;
+
+import com.github.jomnipod.IBFRecord.Iterator;
+
+public final class PDMVersion extends Version {
+    public PDMVersion(Iterator iterator) {
+       super(iterator.nextUnsignedBEShort(), iterator.nextUnsignedBEShort(), iterator.nextUnsignedBEShort());
+    }
+}

--- a/src/main/java/com/github/jomnipod/datatypes/ZeroTerminatedString.java
+++ b/src/main/java/com/github/jomnipod/datatypes/ZeroTerminatedString.java
@@ -30,28 +30,22 @@ import java.nio.charset.Charset;
 
 public class ZeroTerminatedString implements DataType<String> {
 
-	private byte[] buffer;
+	private String value;
 
 	public ZeroTerminatedString(ByteBuffer byteBuffer, int maxLength) {
-		buffer = new byte[maxLength];
-		byteBuffer.get(buffer);
-	}
-
-	public ZeroTerminatedString(InputStream stream, int maxLength) throws IOException {
-		buffer = new byte[maxLength];
-		stream.read(buffer);
+		byte[] buffer = new byte[maxLength+1];
+		int pos = 0;
+		byte got = byteBuffer.get();
+		while (pos < maxLength && byteBuffer.remaining() != 0 && got != 0) {
+			buffer[pos++] = got;
+			got = byteBuffer.get();
+		}
+		buffer[pos] = 0;
+		this.value = new String(buffer, 0, pos, Charset.forName("ISO-8859-1"));
 	}
 
 	@Override
 	public String value() {
-		int length = buffer.length;
-		for (int i = 0; i < buffer.length; i++) {
-			if (buffer[i] == 0) {
-				length = i;
-				break;
-			}
-		}
-
-		return new String(buffer, 0, length, Charset.forName("ISO-8859-1"));
+		return value;
 	}
 }

--- a/src/main/java/com/github/jomnipod/logrecord/ActivateLogRecordDetails.java
+++ b/src/main/java/com/github/jomnipod/logrecord/ActivateLogRecordDetails.java
@@ -27,7 +27,6 @@ import java.util.EnumSet;
 
 import com.github.jomnipod.HistoryLogRecord;
 import com.github.jomnipod.IBFRecord.Iterator;
-import com.github.jomnipod.IBFVersion;
 import com.github.jomnipod.Version;
 
 import lombok.ToString;
@@ -40,8 +39,12 @@ public class ActivateLogRecordDetails extends HistoryLogRecord {
 
 		int lotNumber = iterator.nextUnsignedLEShort();
 		int serialNumber = iterator.nextUnsignedLEShort();
-		Version podVersion = new IBFVersion(iterator);
-		Version interlockVersion = new IBFVersion(iterator);
+		Version podVersion = new Version(iterator.nextByte().intValue(),
+				iterator.nextByte().intValue(),
+				iterator.nextByte().intValue());
+		Version interlockVersion = new Version(iterator.nextByte().intValue(),
+				iterator.nextByte().intValue(),
+				iterator.nextByte().intValue());
 	}
 
 }

--- a/src/main/java/com/github/jomnipod/logrecord/PumpAlarmDetails.java
+++ b/src/main/java/com/github/jomnipod/logrecord/PumpAlarmDetails.java
@@ -131,8 +131,13 @@ public class PumpAlarmDetails implements LogRecordDetails {
 		long lotNumber = iterator.nextUnsignedLEInteger();
 		long seqNumber = iterator.nextUnsignedLEInteger();
 
-		Version processorVersion = new IBFVersion(iterator);
-		Version interlockVersion = new IBFVersion(iterator);
+		Version processorVersion = new Version(iterator.nextByte().intValue(),
+				iterator.nextByte().intValue(),
+				iterator.nextByte().intValue());
+
+		Version interlockVersion = new Version(iterator.nextByte().intValue(),
+				iterator.nextByte().intValue(),
+				iterator.nextByte().intValue());
 	}
 
 	public LocalDateTime timestamp() {

--- a/src/main/java/com/github/jomnipod/logrecord/PumpAlarmDetails.java
+++ b/src/main/java/com/github/jomnipod/logrecord/PumpAlarmDetails.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Mattias Eklöf <mattias.eklof@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -8,10 +8,10 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -19,7 +19,7 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * 
+ *
  */
 package com.github.jomnipod.logrecord;
 


### PR DESCRIPTION
I tried to use this library and I found a few issues:
IBF version elements are 2 bytes long instead of 1 byte.
Parse other versions as three times 1 byte.
Add PDM version support. With this, we know if PDM is Dash or not
ZeroTerminatedString was generating BufferUnderflow errors for some cases. 